### PR TITLE
Multisend contract for cheaper and faster payouts

### DIFF
--- a/contracts/Multisend.sol
+++ b/contracts/Multisend.sol
@@ -1,0 +1,60 @@
+pragma solidity ^0.4.24;
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+contract Ownable {
+  address public owner;
+
+  /**
+   * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+   * account.
+   */
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  /**
+   * @dev Throws if called by any account other than the owner.
+   */
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  /**
+   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @param newOwner The address to transfer ownership to.
+   */
+  function transferOwnership(address newOwner) onlyOwner public {
+    require(newOwner != address(0));
+    owner = newOwner;
+  }
+
+}
+
+/**
+ * @title ERC20Basic
+ * @dev Simpler version of ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/179
+ */
+contract ERC20 {
+  uint256 public totalSupply;
+  function balanceOf(address who) public constant returns (uint256);
+  function transfer(address to, uint256 value) public returns (bool);
+  event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+contract Multisend is Ownable {
+
+  function multisend(address _tokenAddr, address[] _to, uint256[] _value) onlyOwner public returns (bool _success) {
+    require(_to.length == _value.length);
+    // loop through to addresses and send value
+    for (uint8 i = 0; i < _to.length; i++) {
+      ERC20(_tokenAddr).transfer(_to[i], _value[i]);
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
This contract can handle ~150 payouts with a single multisend transaction. The gas cost depends on the history of each address. 

Worst case 32,000 gas per address:
https://ropsten.etherscan.io/tx/0x4761c5611605c551c8b1afce01f3ff3963a317b9c1e60ebb1897608a9050c6ee

Best case 17,600 gas per address:
https://ropsten.etherscan.io/tx/0x1791da53fd2a6904d9e5f8184602910d8c2994d9c6bb4d505c015664e579010d

In both cases it should be half the cost we would pay with 150 single transactions. The payout process should need only half the time that way.

Note:
The contract will pay 0 payouts. A simple if statement to skip them will cost ~15,000 gas even if there is nothing to skip. Throwing an error message is even more expensive. It is cheaper to make sure we never send 0 payouts to the contract.

At the moment the gas limit 8M. If we spend 1 wei more than the block average the miner will include a complete 8M transaction and ignore even the transaction with higher gas price. However that would mean we stop all other Ethereum transactions for a few hours. This will trigger a higher gas price. A better target would be a 4M transaction. Add 10 farmer, calculate gas cost, add the next 10 farmer until the gas price is higher than 4M. Call it and verify the return code. If the return code is false the transaction will faile and we should not send. Most likely the contract was running out of tokens.